### PR TITLE
Fix export definition for OAPV_STATIC_DEFINE to avoid unnecessary exp…

### DIFF
--- a/inc/oapv.h
+++ b/inc/oapv.h
@@ -37,7 +37,11 @@ extern "C"
 {
 #endif
 
+#ifdef OAPV_STATIC_DEFINE
+#define OAPV_EXPORT
+#else
 #include <oapv/oapv_exports.h>
+#endif
 
 /* size of macroblock */
 #define OAPV_LOG2_MB                    (4)


### PR DESCRIPTION
…ort declarartions.

Updated the export definition in oapv.h to ensure oapv_exports.h header is not included for static linking.